### PR TITLE
feat: add 3D defensive shield geometry

### DIFF
--- a/scripts/entities/player.gd
+++ b/scripts/entities/player.gd
@@ -15,6 +15,10 @@ const CONFIG := preload("res://scripts/core/game_config.gd")
 const NEUTRAL_VISUAL_BANK := -PI * 0.5
 const MAX_VISUAL_BANK_DELTA := PI * 0.5
 const BANK_RESPONSE := 7.5
+const SHIELD_ALPHA := 0.10
+const DEFENSIVE_SPECIAL_ALPHA := 0.15
+const SHIELD_RADIUS := 9.5
+const DEFENSIVE_SPECIAL_RADIUS := 10.2
 
 var max_health := 100.0
 var health := 100.0
@@ -37,6 +41,9 @@ var bank := NEUTRAL_VISUAL_BANK
 var _elapsed := 0.0
 var _model_pivot: Node3D
 var _model_bank: Node3D
+var _shield_sphere: MeshInstance3D
+var _defensive_polyhedron: MeshInstance3D
+var _defensive_polyhedron_edges: MeshInstance3D
 
 func _ready() -> void:
 	add_to_group("player")
@@ -54,6 +61,7 @@ func _process(delta: float) -> void:
 	_handle_energy(delta)
 	_handle_regeneration(delta)
 	_handle_weapon(delta)
+	_update_defense_visuals(delta)
 	queue_redraw()
 
 func _handle_modes() -> void:
@@ -222,6 +230,7 @@ func _build_model_view() -> void:
 	_model_bank.rotation.x = bank
 	var model: Node = model_resource.instantiate()
 	_model_bank.add_child(model)
+	_build_defense_geometry()
 	_model_pivot.rotation_degrees = Vector3(0.0, -90.0, 0.0)
 	var light := DirectionalLight3D.new()
 	light.rotation_degrees = Vector3(-50.0, -35.0, 0.0)
@@ -246,6 +255,107 @@ func _build_model_view() -> void:
 	sprite.scale = Vector2(0.58, 0.58)
 	sprite.rotation = -PI * 0.5
 	add_child(sprite)
+	_update_defense_visuals()
+
+func _build_defense_geometry() -> void:
+	_shield_sphere = MeshInstance3D.new()
+	_shield_sphere.name = "ShieldSphere"
+	var sphere := SphereMesh.new()
+	sphere.radius = SHIELD_RADIUS
+	sphere.height = SHIELD_RADIUS * 2.0
+	sphere.radial_segments = 32
+	sphere.rings = 16
+	_shield_sphere.mesh = sphere
+	_shield_sphere.material_override = _transparent_energy_material(Color(0.12, 0.92, 1.0, SHIELD_ALPHA))
+	_shield_sphere.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	_model_bank.add_child(_shield_sphere)
+
+	var polyhedron_data := _icosahedron_data(DEFENSIVE_SPECIAL_RADIUS)
+	_defensive_polyhedron = MeshInstance3D.new()
+	_defensive_polyhedron.name = "DefensiveSpecialIcosahedron"
+	_defensive_polyhedron.mesh = _icosahedron_faces(polyhedron_data["vertices"], polyhedron_data["faces"])
+	_defensive_polyhedron.material_override = _transparent_energy_material(Color(0.30, 1.0, 0.68, DEFENSIVE_SPECIAL_ALPHA))
+	_defensive_polyhedron.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	_defensive_polyhedron.set_meta("face_count", 20)
+	_model_bank.add_child(_defensive_polyhedron)
+
+	_defensive_polyhedron_edges = MeshInstance3D.new()
+	_defensive_polyhedron_edges.name = "DefensiveSpecialEdges"
+	_defensive_polyhedron_edges.mesh = _icosahedron_edges(
+		polyhedron_data["vertices"], polyhedron_data["faces"],
+		_transparent_energy_material(Color(0.45, 1.0, 0.78, DEFENSIVE_SPECIAL_ALPHA))
+	)
+	_defensive_polyhedron_edges.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	_model_bank.add_child(_defensive_polyhedron_edges)
+
+func _transparent_energy_material(color: Color) -> StandardMaterial3D:
+	var material := StandardMaterial3D.new()
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.albedo_color = color
+	material.emission_enabled = true
+	material.emission = Color(color.r, color.g, color.b)
+	material.emission_energy_multiplier = 1.25
+	return material
+
+func _icosahedron_data(radius: float) -> Dictionary:
+	var golden_ratio := (1.0 + sqrt(5.0)) * 0.5
+	var vertices := PackedVector3Array([
+		Vector3(-1.0, golden_ratio, 0.0), Vector3(1.0, golden_ratio, 0.0),
+		Vector3(-1.0, -golden_ratio, 0.0), Vector3(1.0, -golden_ratio, 0.0),
+		Vector3(0.0, -1.0, golden_ratio), Vector3(0.0, 1.0, golden_ratio),
+		Vector3(0.0, -1.0, -golden_ratio), Vector3(0.0, 1.0, -golden_ratio),
+		Vector3(golden_ratio, 0.0, -1.0), Vector3(golden_ratio, 0.0, 1.0),
+		Vector3(-golden_ratio, 0.0, -1.0), Vector3(-golden_ratio, 0.0, 1.0),
+	])
+	for index in range(vertices.size()):
+		vertices[index] = vertices[index].normalized() * radius
+	var faces := PackedInt32Array([
+		0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11,
+		1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
+		3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9,
+		4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1,
+	])
+	return {"vertices": vertices, "faces": faces}
+
+func _icosahedron_faces(vertices: PackedVector3Array, faces: PackedInt32Array) -> ArrayMesh:
+	var face_vertices := PackedVector3Array()
+	for vertex_index in faces:
+		face_vertices.append(vertices[vertex_index])
+	var arrays := []
+	arrays.resize(Mesh.ARRAY_MAX)
+	arrays[Mesh.ARRAY_VERTEX] = face_vertices
+	var mesh := ArrayMesh.new()
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	return mesh
+
+func _icosahedron_edges(vertices: PackedVector3Array, faces: PackedInt32Array, material: Material) -> ImmediateMesh:
+	var mesh := ImmediateMesh.new()
+	var unique_edges := {}
+	mesh.surface_begin(Mesh.PRIMITIVE_LINES, material)
+	for face_offset in range(0, faces.size(), 3):
+		for edge_offset in range(3):
+			var first := faces[face_offset + edge_offset]
+			var second := faces[face_offset + (edge_offset + 1) % 3]
+			var edge_key := "%d:%d" % [mini(first, second), maxi(first, second)]
+			if unique_edges.has(edge_key):
+				continue
+			unique_edges[edge_key] = true
+			mesh.surface_add_vertex(vertices[first])
+			mesh.surface_add_vertex(vertices[second])
+	mesh.surface_end()
+	return mesh
+
+func _update_defense_visuals(delta := 0.0) -> void:
+	if not is_instance_valid(_shield_sphere):
+		return
+	var defensive_special := energy_mode == EnergyMode.DEFENSIVE and special_active
+	_shield_sphere.visible = shield > 0.0 and not defensive_special
+	_defensive_polyhedron.visible = defensive_special
+	_defensive_polyhedron_edges.visible = defensive_special
+	if defensive_special and delta > 0.0:
+		_defensive_polyhedron.rotation.y += delta * 0.45
+		_defensive_polyhedron_edges.rotation.y = _defensive_polyhedron.rotation.y
 
 func _add_fallback_sprite() -> void:
 	var sprite := Sprite2D.new()
@@ -257,9 +367,6 @@ func _draw() -> void:
 	var pulse := 1.0 + sin(_elapsed * 8.0) * 0.12
 	draw_circle(Vector2(-34.0, -9.0), 7.0 * pulse, Color(0.25, 0.8, 1.0, 0.28))
 	draw_circle(Vector2(-34.0, 9.0), 7.0 * pulse, Color(0.25, 0.8, 1.0, 0.28))
-	if shield > 0.0 or (energy_mode == EnergyMode.DEFENSIVE and special_active):
-		var alpha := 0.18 + 0.20 * shield / maxf(max_shield, 1.0)
-		draw_arc(Vector2.ZERO, 39.0, 0.0, TAU, 48, Color(0.15, 1.0, 0.8, alpha), 3.0)
 	if charge_level > 0.0:
 		draw_arc(Vector2.ZERO, 46.0, -PI * 0.5, -PI * 0.5 + TAU * charge_level, 32, Color("ffe45e"), 4.0)
 	if get_meta("debug_hitbox", false):

--- a/tests/capture_player_defenses.gd
+++ b/tests/capture_player_defenses.gd
@@ -1,0 +1,38 @@
+extends Node2D
+
+const PLAYER_SCENE := preload("res://scenes/entities/player.tscn")
+const PLAYER_TYPE := preload("res://scripts/entities/player.gd")
+
+func _ready() -> void:
+	RenderingServer.set_default_clear_color(Color("15171d"))
+	var shield_player := _add_player(Vector2(380.0, 290.0), "DEFENSE · 90% TRANSPARENT")
+	shield_player.shield = shield_player.max_shield
+	shield_player._update_defense_visuals()
+	var special_player := _add_player(Vector2(820.0, 290.0), "DEFENSIVE SPECIAL · 20 FACES · 85% TRANSPARENT")
+	special_player.energy_mode = PLAYER_TYPE.EnergyMode.DEFENSIVE
+	special_player.special_active = true
+	special_player._update_defense_visuals()
+	for _frame in range(12):
+		await get_tree().process_frame
+	await RenderingServer.frame_post_draw
+	var output := "/tmp/capybara-player-defenses.png"
+	var error := get_viewport().get_texture().get_image().save_png(output)
+	print("CAPTURE_OK: %s (%s)" % [output, error_string(error)])
+	get_tree().quit(0 if error == OK else 1)
+
+func _add_player(at: Vector2, label_text: String) -> PLAYER_TYPE:
+	var player := PLAYER_SCENE.instantiate() as PLAYER_TYPE
+	player.position = at
+	player.scale = Vector2.ONE * 2.15
+	add_child(player)
+	player.set_process(false)
+	player.set_visual_bank(1.0, true)
+	var label := Label.new()
+	label.text = label_text
+	label.position = at + Vector2(-250.0, 150.0)
+	label.size = Vector2(500.0, 32.0)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", 17)
+	label.add_theme_color_override("font_color", Color("a9dfff"))
+	add_child(label)
+	return player

--- a/tests/capture_player_defenses.gd.uid
+++ b/tests/capture_player_defenses.gd.uid
@@ -1,0 +1,1 @@
+uid://bdulq6vnwcqux

--- a/tests/capture_player_defenses.tscn
+++ b/tests/capture_player_defenses.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/capture_player_defenses.gd" id="1_capture"]
+
+[node name="CapturePlayerDefenses" type="Node2D"]
+script = ExtResource("1_capture")

--- a/tests/smoke_test.gd
+++ b/tests/smoke_test.gd
@@ -3,6 +3,7 @@ extends Node
 const CONFIG := preload("res://scripts/core/game_config.gd")
 const ENEMY_TYPE := preload("res://scripts/entities/enemy.gd")
 const GAME_TYPE := preload("res://scripts/core/game.gd")
+const PLAYER_TYPE := preload("res://scripts/entities/player.gd")
 
 var failures: Array[String] = []
 
@@ -28,6 +29,22 @@ func _run() -> void:
 	_check(is_instance_valid(game.player), "player exists")
 	_check(game.player.has_node("Ship3DViewport"), "GLB player model is rendered through a SubViewport")
 	_check(FileAccess.file_exists("res://assets/models/player_ship.glb"), "player GLB source is bundled")
+	var ship_viewport := game.player.get_node("Ship3DViewport")
+	var shield_sphere := ship_viewport.find_child("ShieldSphere", true, false) as MeshInstance3D
+	var defensive_special := ship_viewport.find_child("DefensiveSpecialIcosahedron", true, false) as MeshInstance3D
+	_check(is_instance_valid(shield_sphere), "normal defense uses a 3D sphere")
+	_check(is_instance_valid(defensive_special), "defensive special uses a 3D polyhedron")
+	_check(int(defensive_special.get_meta("face_count", 0)) == 20, "defensive special polyhedron has exactly twenty faces")
+	_check(defensive_special.mesh.surface_get_array_len(0) == 60, "defensive special contains twenty triangular faces")
+	_check(is_equal_approx((shield_sphere.material_override as StandardMaterial3D).albedo_color.a, 0.10), "shield sphere is ninety percent transparent")
+	_check(is_equal_approx((defensive_special.material_override as StandardMaterial3D).albedo_color.a, 0.15), "defensive special is eighty-five percent transparent")
+	_check(shield_sphere.visible and not defensive_special.visible, "normal shield geometry is exclusive")
+	game.player.energy_mode = PLAYER_TYPE.EnergyMode.DEFENSIVE
+	game.player.special_active = true
+	game.player._update_defense_visuals()
+	_check(not shield_sphere.visible and defensive_special.visible, "defensive special replaces the shield sphere")
+	game.player.special_active = false
+	game.player._update_defense_visuals()
 	_check(is_equal_approx(game.player.bank, -PI * 0.5), "player rests in side-profile orientation")
 	game.player.set_visual_bank(1.0, true)
 	_check(is_zero_approx(game.player.bank), "moving down exposes the top of the player ship")


### PR DESCRIPTION
## Qué cambia

- Sustituye el arco 2D del escudo por una esfera 3D con 90% de transparencia.
- Representa el especial defensivo con un icosaedro de 20 caras y 85% de transparencia.
- Hace que ambas geometrías acompañen el alabeo del modelo GLB y sean mutuamente excluyentes.
- Añade una escena de captura visual para comparar ambos estados.

## Impacto

La defensa pasa a integrarse con el modelo 3D de la nave. El escudo normal mantiene una lectura esférica sutil y el especial defensivo muestra una estructura facetada diferenciada.

## Validación

- `make clean`
- `make check`
- `make test`
- Captura visual de esfera e icosaedro con render Metal
- Aserciones de alfa, visibilidad exclusiva y 20 caras/60 vértices triangulares
